### PR TITLE
Do not charge one full line item for first resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@ Resources can be pre-paid or post-paid. They can be prorated to daily rates, or 
 
 By default, proration for resources works very similar to [Slack's billing](https://get.slack.help/hc/en-us/articles/218915077), because we thought it was cool, and very fair, so wanted to use it for Robot Ninja.
 
-Specifically:
-
-* Any changes to the number of active resources will be reflected in the next renewal order, prorated daily.
-* If all resources are inactive, the renewal will still charge for a minimum of one resource.
+Specifically, any changes to the number of active resources will be reflected in the next renewal order, prorated daily.
 
 Here’s an example:
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ public function eg_add_minimum_fee( $renewal_order, $resource_ids ) {
 			'order_id'  => $renewal_order->get_id(),
 		) );
 
-		$item->save();
+		$fee_item->save();
 
-		$renewal_order->add_item( $item );
+		$renewal_order->add_item( $fee_item );
 
 		$renewal_order->calculate_totals(); // also saves the order
 	}

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ add_filter( 'wcsr_renewal_line_item_name', 'eg_add_store_to_line_item', 10, 4 );
 
 ### Do the subscription's line item totals display updated amounts each day to account for proration?
 
-No. For now, the subscription line item totals will only display whatever line items were set on it at the time of sign-up.
+No. For now, on the customer facing **My Account > View Subscription** and admin facing **WooCommerce > Edit Subscription** screens, the subscription line item totals will only display whatever line items were set on it at the time of sign-up.
 
 These totals are then used at the time of renewal to determine the prorated amount.
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,53 @@ To deactive a resource linked to a store with ID 23, the following code can be u
 do_action( 'wcsr_deactivate_resource', 23 );
 ```
 
+### Add custom line items or modify prorated totals
+
+If you want to customize the prorated amounts, or apply other logic to orders that have been prorated, like adding other line items, the `'wcsr_after_renewal_order_prorated'` hook is triggered after a renewal order's totals have been prorated.
+
+For example, we use this on Robot Ninja to implmement a minimum amount for renewal orders of $9 by adding custom fee line items to orders with a prorated total of less than $9.
+
+Callbacks on the `wcsr_after_renewal_order_prorated` filter receive:
+
+1. an `WC_Order` object representing the prorated renewal order as the first param.
+2. an array of resource IDs for the matching subscription as the 2nd param.
+
+> Note: this filter is only trigger for orders with prorated amounts, making it easier to use then existing, more generic hooks, like `'wcs_renewal_order_created'`.
+
+#### Custom Resource Line Item Name Example
+
+The following snippet shows code similar to that used on Robot Ninja to enforce a minimum monthly access fee of $9. If the prorated renewal order is less than $9 based on the resource usage during the prior month, then a new fee line item is added to the renewal order for difference.
+
+```php
+public function eg_add_minimum_fee( $renewal_order, $resource_ids ) {
+
+	if ( $renewal_order->get_total() < 9 ) {
+
+		$fee_item = new WC_Order_Item_Fee();
+
+		$fee_item->set_props( array(
+			'name'      => 'Robot Ninja Gap Fee for Monthly Minimum',
+			'tax_class' => '',
+			'total'     => wc_format_decimal( 9.00 - $renewal_order->get_total() ),
+			'total_tax' => '',
+			'taxes'     => array(
+				'total' => 0,
+			),
+			'order_id'  => $renewal_order->get_id(),
+		) );
+
+		$item->save();
+
+		$renewal_order->add_item( $item );
+
+		$renewal_order->calculate_totals(); // also saves the order
+	}
+
+	return $renewal_order;
+}
+add_filter( 'wcsr_after_renewal_order_prorated', ''eg_add_minimum_fee, 10, 2 );_
+```
+
 ### Link a Resource to Line Item Name on Renewal Order
 
 Each resource will be set as a separate line item on the renewal orders (using the correct product IDs to make sure reports are accurate).

--- a/includes/class-wcsr-resource-manager.php
+++ b/includes/class-wcsr-resource-manager.php
@@ -113,7 +113,7 @@ class WCSR_Resource_Manager {
 		$is_prorated  = false;
 		$resource_ids = WCSR_Data_Store::store()->get_resource_ids_for_subscription( $subscription->get_id() );
 
-		if ( ! empty( $resource_ids ) && count( $resource_ids ) > 1 ) {
+		if ( ! empty( $resource_ids ) ) {
 
 			// First, get the line items representing the resource so we can figure out things like cost for it
 			$line_items = $renewal_order->get_items();

--- a/includes/class-wcsr-resource-manager.php
+++ b/includes/class-wcsr-resource-manager.php
@@ -195,6 +195,11 @@ class WCSR_Resource_Manager {
 			}
 		}
 
+		// Allow 3rd party code to perform their own proration or other logic just after we have prorate
+		if ( $is_prorated ) {
+			$renewal_order = apply_filters( 'wcsr_after_renewal_order_prorated', $renewal_order, $resource_ids );
+		}
+
 		return $renewal_order;
 	}
 


### PR DESCRIPTION
Prorate all line items for all resources rather than ignoring first resource.

For 3rd party code to implement a minimum fee, like we want on Robot Ninja, add a new `'wcsr_after_renewal_order_prorated'` filter (as well as a new section in the README explaining how to use it, /cc @mattallan).
