### PR TITLE
A fix for the get_active_days calculations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: php
+
+sudo: false
+ 
+notifications:
+  email: false
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+
+dist: precise
+
+branches:
+  only:
+    - master
+
+script: 
+  - phpunit -c phpunit.xml --coverage-clover clover.xml
+
+after_script:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# WooCommerce Subscriptions Resource
+# WooCommerce Subscriptions Resource [![Build Status](https://travis-ci.org/Prospress/woocommerce-subscriptions-resource.svg?branch=master)](https://travis-ci.org/Prospress/woocommerce-subscriptions-resource)  [![license: GPL v2](https://img.shields.io/badge/license-GPLv2-blue.svg)](http://opensource.org/licenses/GPL-2.0)
+
 
 A library to track and prorate payments for a subscription using WooCommerce Subscriptions based on the status of an external resource.
 

--- a/includes/class-wcsr-resource-manager.php
+++ b/includes/class-wcsr-resource-manager.php
@@ -139,6 +139,7 @@ class WCSR_Resource_Manager {
 					// Now add a prorated line item for each resource based on the resource's usage for this period
 					$days_in_period = wcs_estimate_periods_between( $from_timestamp, $renewal_order->get_date_created()->getTimestamp(), 'day', 'floor' );
 					$days_active    = $resource->get_days_active( $from_timestamp, $renewal_order->get_date_created()->getTimestamp() );
+					$days_active_ratio = ( $days_active > $days_in_period ? $days_in_period : $days_active ) / $days_in_period; // make sure the days active is not more than the days in period and also calcu
 
 					foreach ( $line_items as $line_item ) {
 
@@ -152,15 +153,15 @@ class WCSR_Resource_Manager {
 
 							foreach( $taxes as $total_type => $tax_values ) {
 								foreach( $tax_values as $tax_id => $tax_value ) {
-									$taxes[ $total_type ][ $tax_id ] = $tax_value / $days_in_period * $days_active;
+									$taxes[ $total_type ][ $tax_id ] = $tax_value * $days_active_ratio;
 								}
 							}
 
 							$new_item->set_props( array(
-								'subtotal'     => $line_item->get_subtotal() / $days_in_period * $days_active,
-								'total'        => $line_item->get_total() / $days_in_period * $days_active,
-								'subtotal_tax' => $line_item->get_subtotal_tax() / $days_in_period * $days_active,
-								'total_tax'    => $line_item->get_total_tax() / $days_in_period * $days_active,
+								'subtotal'     => $line_item->get_subtotal() * $days_active_ratio,
+								'total'        => $line_item->get_total() * $days_active_ratio,
+								'subtotal_tax' => $line_item->get_subtotal_tax() * $days_active_ratio,
+								'total_tax'    => $line_item->get_total_tax() * $days_active_ratio,
 								'taxes'        => $taxes,
 							) );
 

--- a/includes/class-wcsr-resource-manager.php
+++ b/includes/class-wcsr-resource-manager.php
@@ -139,7 +139,7 @@ class WCSR_Resource_Manager {
 					// Now add a prorated line item for each resource based on the resource's usage for this period
 					$days_in_period = wcs_estimate_periods_between( $from_timestamp, $renewal_order->get_date_created()->getTimestamp(), 'day', 'floor' );
 					$days_active    = $resource->get_days_active( $from_timestamp, $renewal_order->get_date_created()->getTimestamp() );
-					$days_active_ratio = ( $days_active > $days_in_period ? $days_in_period : $days_active ) / $days_in_period; // make sure the days active is not more than the days in period and also calcu
+					$days_active_ratio = ( $days_active >= $days_in_period ) ? 1 : $days_active / $days_in_period; // calculate the days active to days in period ratio. If the active days is more than the days in period make sure we return 1
 
 					foreach ( $line_items as $line_item ) {
 

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -251,21 +251,16 @@ class WCSR_Resource extends WC_Data {
 	}
 
 	/**
-	 * Prototype/demo conditional check for whether a timestamp is on the same "day" as another timestamp
+	 * Conditional check for whether a timestamp is on the same 24 hour block as another timestamp
 	 *
 	 * The catch is the "day" is not typical calendar day - it based on a 24 hour period from the $start_timestamp
 	 *
-	 * The $start_timestamp could be the actual time it was first activated of the start of the period.
+	 * Uses the $start_timestamp to loop over and add DAY_IN_SECONDS to the time until it reaches the same 24 hour block as the $compare_timestamp
+	 * This function then checks whether the $current_timestamp and the $compare_timestamp are within the same 24 hour block
 	 *
-	 * Takes the starting timestamp and gets the time our days start from.
-	 * Takes the timestamp we are checking if we are on the same day as and gets the date, previous days date and time
-	 * Works out whether the current day started on the same date as the one we are comparing with or a day earlier and works makes a time stampe fo when the day starts
-	 * Works out when the days ends
-	 * Check if our timestamp is with the start and end dates we have determined
-	 *
-	 * @param  int  $current_timestamp    [description]
-	 * @param  int  $compare_timestamp [description]
-	 * @param  int  $start_timestamp  [description]
+	 * @param  int  $current_timestamp The current timestamp being checked
+	 * @param  int  $compare_timestamp The timestamp used to check if the $current_timestamp is on the same 24 hour block
+	 * @param  int  $start_timestamp  The start timestamp of the period (to calculate when the 24 hour blocks start)
 	 * @return boolean true on same day | false if not
 	 */
 	public static function is_on_same_day( $current_timestamp, $compare_timestamp, $start_timestamp ) {

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -216,7 +216,7 @@ class WCSR_Resource extends WC_Data {
 			$deactivation_time = isset( $deactivation_times[ $i ] ) ? $deactivation_times[ $i ] : $to_timestamp;
 
 			// skip over any days that are activated/deactivated on the same day and have already been accounted for
-			if ( $i !== 0 && self::is_on_same_day( $deactivation_time, $deactivation_times[ $i - 1 ], $activation_times[0] ) ) {
+			if ( $i !== 0 && self::is_on_same_day( $deactivation_time, $deactivation_times[ $i - 1 ], $from_timestamp ) ) {
 				continue;
 			}
 
@@ -227,10 +227,15 @@ class WCSR_Resource extends WC_Data {
 			$days_active += $days_by_time;
 
 			// If days based on time is only 1 but it was "across a day" we may need to adjust IF NOT accounted for already
-			if ( $days_by_time == 1 && ! self::is_on_same_day( $activation_time, $deactivation_time, $activation_times[0] ) ) {
+			if ( $days_by_time == 1 && ! self::is_on_same_day( $activation_time, $deactivation_time, $from_timestamp ) ) {
+
+				// handle situation if first activation crosses a day
+				if ( $i == 0 && ! self::is_on_same_day( $activation_time, $deactivation_time, $from_timestamp ) ) {
+					$days_active += 1;
+				}
 
 				// if this activation didn't start on the same day as previous activation it is safe to add an extra day
-				if ( ! self::is_on_same_day( $activation_time, $deactivation_times[ $i - 1 ], $activation_times[0] ) ) {
+				if ( $i !== 0 && ! self::is_on_same_day( $activation_time, $deactivation_times[ $i - 1 ], $from_timestamp ) ) {
 					$days_active += 1;
 				}
 			}

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -191,9 +191,10 @@ class WCSR_Resource extends WC_Data {
 	 * @return int
 	 */
 	public function get_days_active( $from_timestamp, $to_timestamp = null ) {
+		$days_active = 0;
 
 		if ( false === $this->has_been_activated() ) {
-			return 0;
+			return $days_active;
 		}
 
 		if ( is_null( $to_timestamp ) ) {
@@ -204,18 +205,16 @@ class WCSR_Resource extends WC_Data {
 		$activation_times   = self::get_timestamps_between( $this->get_activation_timestamps(), $from_timestamp, $to_timestamp );
 		$deactivation_times = self::get_timestamps_between( $this->get_deactivation_timestamps(), $from_timestamp, $to_timestamp );
 
-		// Now find the number of days between the timestamps where the resource was active (the resource must be inactive for more than 24 hours to be considered inactive for a given day)
-		$days_active = floor( ( $to_timestamp - $from_timestamp ) / DAY_IN_SECONDS );
-
-		// First remove any gap between the $from_timestamp and the resources creation date
-		if ( $this->get_date_created()->getTimestamp() > $from_timestamp ) {
-			$days_active -= floor( ( $this->get_date_created()->getTimestamp() - $from_timestamp ) / DAY_IN_SECONDS );
+		// if the first activation date is after the first deactivation date, make sure we append the start timestamps to act as the first "activated" date for the resource
+		if ( ! isset( $activation_times[0] ) || ( isset( $deactivation_times[0] ) && $activation_times[0] > $deactivation_times[0] ) ) {
+			$start_timestamp = ( $this->get_date_created()->getTimestamp() > $from_timestamp ) ? $this->get_date_created()->getTimestamp() : $from_timestamp;
+			array_unshift( $activation_times, $start_timestamp );
 		}
 
 		foreach ( $activation_times as $i => $activation_time ) {
-			if ( isset( $deactivation_times[ $i ] ) ) {
-				$days_active -= floor( ( $activation_time - $deactivation_times[ $i ] ) / DAY_IN_SECONDS );
-			}
+			// If there is corresponding deactivation timestamp, the resouce has deactivated before the end of the period so that's the time we want, otherwise, use the end of the period as the resource was still active at end of the period
+			$deactivation_time = isset( $deactivation_times[ $i ] ) ? $deactivation_times[ $i ] : $to_timestamp;
+			$days_active += absint( ceil( ( $deactivation_time - $activation_time ) / DAY_IN_SECONDS ) );
 		}
 
 		return $days_active;

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -263,28 +263,10 @@ class WCSR_Resource extends WC_Data {
 	 * @return boolean true on same day | false if not
 	 */
 	public static function is_on_same_day( $current_timestamp, $compare_timestamp, $start_timestamp ) {
-
-		$start_time = gmdate( 'H:i:s', $start_timestamp );
-		$start_hour = gmdate( 'H', $start_timestamp );
-		$start_min  = gmdate( 'i', $start_timestamp );
-		$start_sec  = gmdate( 's', $start_timestamp );
-
-		$compare_day  = gmdate( 'Y-m-d', $compare_timestamp );
-		$compare_day_previous  = gmdate( 'Y-m-d', strtotime( '-1 day', $compare_timestamp ) );
-		$compare_hour = gmdate( 'H', $compare_timestamp );
-		$compare_min  = gmdate( 'i', $compare_timestamp );
-		$compare_sec  = gmdate( 's', $compare_timestamp );
-
-		$start_of_the_day_date_time = $compare_day . ' ' . $start_time;
-		$start_of_the_day = strtotime( $start_of_the_day_date_time );
-
-		// Adjust for H:M:S being less
-		if ( $compare_hour < $start_hour || ( ( $compare_hour == $start_hour ) && ( $compare_min < $start_min ) ) || ( ( $compare_hour == $start_hour ) && ( $compare_min == $start_min ) && ( $compare_sec < $start_sec ) ) ) {
-			$start_of_the_day_date_time = $compare_day_previous . ' ' . $start_time;
-			$start_of_the_day = strtotime( $start_of_the_day_date_time );
+		for ( $end_of_the_day = $start_timestamp; $end_of_the_day <= $compare_timestamp; $end_of_the_day += DAY_IN_SECONDS ) {
+			// The loop controls take care of incrementing the end day (3rd expression) until the day after the compare date (2nd expression), but we also want to set the start date so we do that here using the current value of end day (which will be the start day in the final iteration as the 3rd expression in the loop hasn't run yet)
+			$start_of_the_day = $end_of_the_day;
 		}
-
-		$end_of_the_day = strtotime( '+1 day', $start_of_the_day );
 
 		// Compare timestamp to see if it is within our ranges
 		if ( ( $current_timestamp >= $start_of_the_day ) && ( $current_timestamp < $end_of_the_day ) ) {

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -216,14 +216,14 @@ class WCSR_Resource extends WC_Data {
 			$deactivation_time = isset( $deactivation_times[ $i ] ) ? $deactivation_times[ $i ] : $to_timestamp;
 
 			// skip over any days that are activated/deactivated on the same day and have already been accounted for
-			if ( $i !== 0 && gmdate( 'Y-m-d', $deactivation_times[ --$i ] ) == gmdate( 'Y-m-d', $deactivation_time ) ) {
+			if ( $i !== 0 && gmdate( 'Y-m-d', $deactivation_times[ $i - 1 ] ) == gmdate( 'Y-m-d', $deactivation_time ) ) {
 				continue;
 			}
 
 			$days_active += absint( ceil( ( $deactivation_time - $activation_time ) / DAY_IN_SECONDS ) );
 
 			// if the activation date is the same as the previous activation date, minus one off one day active from the result since that day was already accounted for previously
-			if ( $i !== 0 && gmdate( 'Y-m-d', $activation_times[ --$i ] ) == gmdate( 'Y-m-d', $activation_times[ $i ] ) ) {
+			if ( $i !== 0 && gmdate( 'Y-m-d', $activation_times[ $i - 1 ] ) == gmdate( 'Y-m-d', $activation_times[ $i ] ) ) {
 				$days_active -= 1;
 			}
 		}

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -220,7 +220,20 @@ class WCSR_Resource extends WC_Data {
 				continue;
 			}
 
-			$days_active += intval( ceil( ( $deactivation_time - $activation_time ) / DAY_IN_SECONDS ) );
+			// Calculate days based on time between
+			$days_by_time = intval( ceil( ( $deactivation_time - $activation_time ) / DAY_IN_SECONDS ) );
+
+			// Increase our tally
+			$days_active += $days_by_time;
+
+			// If days based on time is only 1 but it was "across a day" we may need to adjust IF NOT accounted for already
+			if ( $days_by_time == 1 && ! self::is_on_same_day( $activation_time, $deactivation_time, $activation_times[0] ) ) {
+
+				// if this activation didn't start on the same day as previous activation it is safe to add an extra day
+				if ( ! self::is_on_same_day( $activation_time, $deactivation_times[ $i - 1 ], $activation_times[0] ) ) {
+					$days_active += 1;
+				}
+			}
 		}
 
 		return $days_active;

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -205,14 +205,14 @@ class WCSR_Resource extends WC_Data {
 		$activation_times   = self::get_timestamps_between( $this->get_activation_timestamps(), $from_timestamp, $to_timestamp );
 		$deactivation_times = self::get_timestamps_between( $this->get_deactivation_timestamps(), $from_timestamp, $to_timestamp );
 
-		// if the first activation date is after the first deactivation date, make sure we append the start timestamps to act as the first "activated" date for the resource
+		// if the first activation date is after the first deactivation date, make sure we prepend the start timestamp to act as the first "activated" date for the resource
 		if ( ! isset( $activation_times[0] ) || ( isset( $deactivation_times[0] ) && $activation_times[0] > $deactivation_times[0] ) ) {
 			$start_timestamp = ( $this->get_date_created()->getTimestamp() > $from_timestamp ) ? $this->get_date_created()->getTimestamp() : $from_timestamp;
 			array_unshift( $activation_times, $start_timestamp );
 		}
 
 		foreach ( $activation_times as $i => $activation_time ) {
-			// If there is corresponding deactivation timestamp, the resouce has deactivated before the end of the period so that's the time we want, otherwise, use the end of the period as the resource was still active at end of the period
+			// If there is corresponding deactivation timestamp, the resource has deactivated before the end of the period so that's the time we want, otherwise, use the end of the period as the resource was still active at end of the period
 			$deactivation_time = isset( $deactivation_times[ $i ] ) ? $deactivation_times[ $i ] : $to_timestamp;
 
 			// skip over any days that are activated/deactivated on the same day and have already been accounted for
@@ -247,11 +247,11 @@ class WCSR_Resource extends WC_Data {
 	/**
 	 * Prototype/demo conditional check for whether a timestamp is on the same "day" as another timestamp
 	 *
-	 * The catch is the "day" is not typical calendar day - it based on a 24 hour period from initial activation
+	 * The catch is the "day" is not typical calendar day - it based on a 24 hour period from the $start_timestamp
 	 *
-	 * Initial activation could be the actual time it was first activated of the start of the period.
+	 * The $start_timestamp could be the actual time it was first activated of the start of the period.
 	 *
-	 * Takes the activation/starting timestamp and gets the time our days start from.
+	 * Takes the starting timestamp and gets the time our days start from.
 	 * Takes the timestamp we are checking if we are on the same day as and gets the date, previous days date and time
 	 * Works out whether the current day started on the same date as the one we are comparing with or a day earlier and works makes a time stampe fo when the day starts
 	 * Works out when the days ends

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -221,7 +221,7 @@ class WCSR_Resource extends WC_Data {
 			// If there is corresponding deactivation timestamp, the resource has deactivated before the end of the period so that's the time we want, otherwise, use the end of the period as the resource was still active at end of the period
 			$deactivation_time = isset( $deactivation_times[ $i ] ) ? $deactivation_times[ $i ] : $to_timestamp;
 
-			// skip over any days that are activated/deactivated on the same day and have already been accounted for
+			// skip over any days that are activated/deactivated on the same 24 hour block and have already been accounted for
 			if ( $i !== 0 && self::is_on_same_day( $deactivation_time, $deactivation_times[ $i - 1 ], $from_timestamp ) ) {
 				continue;
 			}
@@ -232,15 +232,15 @@ class WCSR_Resource extends WC_Data {
 			// Increase our tally
 			$days_active += $days_by_time;
 
-			// If days based on time is only 1 but it was "across a day" we may need to adjust IF NOT accounted for already
+			// If days based on time is only 1 but it was "across a 24 hour block" we may need to adjust IF NOT accounted for already
 			if ( $days_by_time == 1 && ! self::is_on_same_day( $activation_time, $deactivation_time, $from_timestamp ) ) {
 
-				// handle situation if first activation crosses a day
+				// handle situation if first activation crosses a 24 hour block
 				if ( $i == 0 && ! self::is_on_same_day( $activation_time, $deactivation_time, $from_timestamp ) ) {
 					$days_active += 1;
 				}
 
-				// if this activation didn't start on the same day as previous activation it is safe to add an extra day
+				// if this activation didn't start on the same 24 hour block as previous activation it is safe to add an extra day
 				if ( $i !== 0 && ! self::is_on_same_day( $activation_time, $deactivation_times[ $i - 1 ], $from_timestamp ) ) {
 					$days_active += 1;
 				}
@@ -253,7 +253,7 @@ class WCSR_Resource extends WC_Data {
 	/**
 	 * Conditional check for whether a timestamp is on the same 24 hour block as another timestamp
 	 *
-	 * The catch is the "day" is not typical calendar day - it based on a 24 hour period from the $start_timestamp
+	 * The catch is the "day" is not typical calendar day - it based on a 24 hour block from the $start_timestamp
 	 *
 	 * Uses the $start_timestamp to loop over and add DAY_IN_SECONDS to the time until it reaches the same 24 hour block as the $compare_timestamp
 	 * This function then checks whether the $current_timestamp and the $compare_timestamp are within the same 24 hour block
@@ -261,7 +261,7 @@ class WCSR_Resource extends WC_Data {
 	 * @param  int  $current_timestamp The current timestamp being checked
 	 * @param  int  $compare_timestamp The timestamp used to check if the $current_timestamp is on the same 24 hour block
 	 * @param  int  $start_timestamp  The start timestamp of the period (to calculate when the 24 hour blocks start)
-	 * @return boolean true on same day | false if not
+	 * @return boolean true on same 24 hour block | false if not
 	 */
 	protected static function is_on_same_day( $current_timestamp, $compare_timestamp, $start_timestamp ) {
 		for ( $end_of_the_day = $start_timestamp; $end_of_the_day <= $compare_timestamp; $end_of_the_day += DAY_IN_SECONDS ) {

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -208,6 +208,12 @@ class WCSR_Resource extends WC_Data {
 		// if the first activation date is after the first deactivation date, make sure we prepend the start timestamp to act as the first "activated" date for the resource
 		if ( ! isset( $activation_times[0] ) || ( isset( $deactivation_times[0] ) && $activation_times[0] > $deactivation_times[0] ) ) {
 			$start_timestamp = ( $this->get_date_created()->getTimestamp() > $from_timestamp ) ? $this->get_date_created()->getTimestamp() : $from_timestamp;
+
+			// before setting the start timestamp as the created time or the $from_timestamp make sure the deactivation date doesn't come before it
+			if ( isset( $deactivation_times[0] ) && $start_timestamp > $deactivation_times[0] ) {
+				throw new Exception( 'The resource first deactivation date in the period comes before the resource start time or before the beginning of the period. This is invalid.' );
+			}
+
 			array_unshift( $activation_times, $start_timestamp );
 		}
 

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -214,7 +214,18 @@ class WCSR_Resource extends WC_Data {
 		foreach ( $activation_times as $i => $activation_time ) {
 			// If there is corresponding deactivation timestamp, the resouce has deactivated before the end of the period so that's the time we want, otherwise, use the end of the period as the resource was still active at end of the period
 			$deactivation_time = isset( $deactivation_times[ $i ] ) ? $deactivation_times[ $i ] : $to_timestamp;
+
+			// skip over any days that are activated/deactivated on the same day and have already been accounted for
+			if ( $i !== 0 && gmdate( 'Y-m-d', $deactivation_times[ --$i ] ) == gmdate( 'Y-m-d', $deactivation_time ) ) {
+				continue;
+			}
+
 			$days_active += absint( ceil( ( $deactivation_time - $activation_time ) / DAY_IN_SECONDS ) );
+
+			// if the activation date is the same as the previous activation date, minus one off one day active from the result since that day was already accounted for previously
+			if ( $i !== 0 && gmdate( 'Y-m-d', $activation_times[ --$i ] ) == gmdate( 'Y-m-d', $activation_times[ $i ] ) ) {
+				$days_active -= 1;
+			}
 		}
 
 		return $days_active;

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -263,7 +263,7 @@ class WCSR_Resource extends WC_Data {
 	 * @param  int  $start_timestamp  The start timestamp of the period (to calculate when the 24 hour blocks start)
 	 * @return boolean true on same day | false if not
 	 */
-	public static function is_on_same_day( $current_timestamp, $compare_timestamp, $start_timestamp ) {
+	protected static function is_on_same_day( $current_timestamp, $compare_timestamp, $start_timestamp ) {
 		for ( $end_of_the_day = $start_timestamp; $end_of_the_day <= $compare_timestamp; $end_of_the_day += DAY_IN_SECONDS ) {
 			// The loop controls take care of incrementing the end day (3rd expression) until the day after the compare date (2nd expression), but we also want to set the start date so we do that here using the current value of end day (which will be the start day in the final iteration as the 3rd expression in the loop hasn't run yet)
 			$start_of_the_day = $end_of_the_day;

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -220,7 +220,7 @@ class WCSR_Resource extends WC_Data {
 				continue;
 			}
 
-			$days_active += absint( ceil( ( $deactivation_time - $activation_time ) / DAY_IN_SECONDS ) );
+			$days_active += intval( ceil( ( $deactivation_time - $activation_time ) / DAY_IN_SECONDS ) );
 
 			// if the activation date is the same as the previous activation date, minus one off one day active from the result since that day was already accounted for previously
 			if ( $i !== 0 && gmdate( 'Y-m-d', $activation_times[ $i - 1 ] ) == gmdate( 'Y-m-d', $activation_times[ $i ] ) ) {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	processIsolation="false"
+	stopOnFailure="false"
+	bootstrap="tests/bootstrap.php"
+	>
+	<testsuites>
+		<testsuite name="WooCommerce Subscriptions Resource">
+			<directory suffix=".php">./tests/unit</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,6 +38,21 @@ class WCSR_Unit_Tests_Bootstrap {
 		require_once( 'mocks/class-wc-data.php' );
 
 		require_once( $this->plugin_dir . '/includes/class-wcsr-resource.php' );
+
+		// Load relevant class aliases for PHPUnit 6 (ran on PHP v7.0+ in Travis)
+		if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner\Version::id(), '6.0', '>=' ) ) {
+			class_alias( 'PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase' );
+			// class_alias( 'PHPUnit\Framework\Exception', 'PHPUnit_Framework_Exception' );
+			// class_alias( 'PHPUnit\Framework\ExpectationFailedException', 'PHPUnit_Framework_ExpectationFailedException' );
+			// class_alias( 'PHPUnit\Framework\Error\Notice', 'PHPUnit_Framework_Error_Notice' );
+			// class_alias( 'PHPUnit\Framework\Test', 'PHPUnit_Framework_Test' );
+			// class_alias( 'PHPUnit\Framework\Warning', 'PHPUnit_Framework_Warning' );
+			// class_alias( 'PHPUnit\Framework\AssertionFailedError', 'PHPUnit_Framework_AssertionFailedError' );
+			// class_alias( 'PHPUnit\Framework\TestSuite', 'PHPUnit_Framework_TestSuite' );
+			// class_alias( 'PHPUnit\Framework\TestListener', 'PHPUnit_Framework_TestListener' );
+			// class_alias( 'PHPUnit\Util\GlobalState', 'PHPUnit_Util_GlobalState' );
+			// class_alias( 'PHPUnit\Util\Getopt', 'PHPUnit_Util_Getopt' );
+		}
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * WCS_Unit_Tests_Bootstrap
+ *
+ * @since 2.0
+ */
+class WCSR_Unit_Tests_Bootstrap {
+
+	/** @var \WCSR_Unit_Tests_Bootstrap instance */
+	protected static $instance = null;
+
+	/** @var string plugin directory */
+	protected $plugin_dir;
+
+	/**
+	 * Setup the unit testing environment
+	 *
+	 * @since 2.0
+	 */
+	function __construct() {
+
+		ini_set( 'display_errors','on' );
+		error_reporting( E_ALL );
+
+		// Make sure ABSPATH is defined so files load
+		if ( ! defined( 'ABSPATH' ) ) {
+			define( 'ABSPATH', '' );
+		}
+
+		// Make sure the DAY_IN_SECONDS constant is defined so we can use it without rely on WP's definition of it
+		if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+			define( 'DAY_IN_SECONDS', 60 * 60 * 24 );
+		}
+
+		$this->plugin_dir = dirname( dirname( __FILE__ ) );
+
+		// Define a mock WC_Data object rather than requiring WooCommerce (we shouldn't be relying on or testing any WC_Data methods anyway)
+		require_once( 'mocks/class-wc-data.php' );
+
+		require_once( $this->plugin_dir . '/includes/class-wcsr-resource.php' );
+	}
+
+	/**
+	 * Get the single class instance
+	 *
+	 * @since 2.0
+	 * @return WCS_Unit_Tests_Bootstrap
+	 */
+	public static function instance() {
+
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+}
+WCSR_Unit_Tests_Bootstrap::instance();

--- a/tests/mocks/class-wc-data.php
+++ b/tests/mocks/class-wc-data.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * An empty WC_Data class for use with unit tests
+ *
+ * We don't want our unit tests to depend on anything in the parent
+ * WC_Data class, so we can simply define an empty class here for use
+ * with testing.
+ */
+class WC_Data {
+
+	/**
+	 * Get an instance for a given resource
+	 *
+	 * @return null
+	 */
+	public function __construct( $resource ) {
+	}
+}

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -271,6 +271,21 @@ class WCSR_Resource_Test extends PHPUnit_Framework_TestCase {
 				'deactivation_times'   => array( '2017-09-14 21:00:03', '2017-09-15 01:15:11' ),
 				'expected_days_active' => 1,
 			),
+
+			/*
+			 * Simulate an existing resource that is activated for 5ish hours crossing into the next day and then left inactive.
+			 * Same overall time as Test 15 (without the multiple activating and deactiving on the same day)
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
+			 * 1. activated for 5 hours, then deactivatd for the rest of the cycle
+			 */
+			16 => array(
+				'date_created'         => '2017-06-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 20:00:03' ),
+				'deactivation_times'   => array( '2017-09-15 01:15:11' ),
+				'expected_days_active' => 1,
+			),
 		);
 	}
 

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -364,6 +364,38 @@ class WCSR_Resource_Test extends PHPUnit_Framework_TestCase {
 				'deactivation_times'   => array( '2017-09-14 21:13:13', '2017-09-15 03:00:00', ),
 				'expected_days_active' => 1,
 			),
+
+			// First activation is on a different day to start AND crosses a "day"
+			25 => array(
+				'date_created'         => '2017-09-16 08:13:14',
+				'activation_times'     => array( '2017-09-16 08:13:14' ),
+				'deactivation_times'   => array( '2017-09-16 10:13:14' ),
+				'expected_days_active' => 2,
+			),
+
+			// First activation is on a different day to start AND crosses a "day", plus another activation that crosses same day
+			26 => array(
+				'date_created'         => '2017-09-16 08:13:14',
+				'activation_times'     => array( '2017-09-16 08:13:14', '2017-09-17 08:13:14' ),
+				'deactivation_times'   => array( '2017-09-16 10:13:14', '2017-09-18 08:13:14' ),
+				'expected_days_active' => 3,
+			),
+
+			// First activation is on a different day to start AND crosses a "day", plus activation that doesn't cross 2 days
+			27 => array(
+				'date_created'         => '2017-09-16 08:13:14',
+				'activation_times'     => array( '2017-09-16 08:13:14', '2017-09-17 10:13:14' ),
+				'deactivation_times'   => array( '2017-09-16 10:13:14', '2017-09-18 08:13:14' ),
+				'expected_days_active' => 3,
+			),
+
+			// First activation is on a different day to start AND crosses a "day", plus more activations which also crosses 2 days
+			28 => array(
+				'date_created'         => '2017-09-16 08:13:14',
+				'activation_times'     => array( '2017-09-16 08:13:14', '2017-09-18 08:13:14' ),
+				'deactivation_times'   => array( '2017-09-16 10:13:14', '2017-09-18 10:13:14' ),
+				'expected_days_active' => 4,
+			),
 		);
 	}
 

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -190,6 +190,7 @@ class WCSR_Resource_Test extends PHPUnit_Framework_TestCase {
 				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-14 13:13:14', '2017-09-14 20:00:03' ),
 				'deactivation_times'   => array( '2017-09-14 10:35:43', '2017-09-14 17:24:10', '2017-09-16 17:24:10' ),
 				'expected_days_active' => 2,
+				'expected_days_active' => 3,
 			),
 		);
 	}

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -354,6 +354,16 @@ class WCSR_Resource_Test extends PHPUnit_Framework_TestCase {
 				'deactivation_times'   => array( '2017-09-15 09:00:13', '2017-09-30 08:15:11', '2017-09-30 11:00:03', '2017-10-02 10:00:03' ),
 				'expected_days_active' => 17,
 			),
+
+			// Demonstrates most basic difference between comparing same day based on calendar days vs 24 hour periods
+			// Branch issue_11 picks this up as 2 days
+			// This Branch picks this up as 1 day
+			24 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-15 01:00:00', ),
+				'deactivation_times'   => array( '2017-09-14 21:13:13', '2017-09-15 03:00:00', ),
+				'expected_days_active' => 1,
+			),
 		);
 	}
 

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -311,4 +311,142 @@ class WCSR_Resource_Test extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals( $expected_days_active, $resource_mock->get_days_active( self::$from_timestamp, self::$to_timestamp ) );
 	}
+
+	/**
+	 * Provide data to whether timestamp is on same day
+	 */
+	public function provider_is_on_same_day() {
+		return array(
+
+			// Exactly start of same day 00:00:00
+			0 => array(
+				'current_timestamp' => strtotime( '2017-09-14 09:13:14' ),
+				'compare_timestamp' => strtotime( '2017-09-14 09:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => true,
+			),
+
+			// Just within the same day 23:59:59
+			1 => array(
+				'current_timestamp' => strtotime( '2017-09-15 09:13:13' ),
+				'compare_timestamp' => strtotime( '2017-09-14 09:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => true,
+			),
+
+			// start of the next day 00:00:00
+			2 => array(
+				'current_timestamp' => strtotime( '2017-09-15 09:13:14' ),
+				'compare_timestamp' => strtotime( '2017-09-14 09:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => false,
+			),
+
+			// move comparison date and increase current second
+			3 => array(
+				'current_timestamp' => strtotime( '2017-09-20 09:13:14' ),
+				'compare_timestamp' => strtotime( '2017-09-19 09:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => false,
+			),
+
+			// move comparison date and decrease current second
+			4 => array(
+				'current_timestamp' => strtotime( '2017-09-20 09:13:13' ),
+				'compare_timestamp' => strtotime( '2017-09-19 09:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => true,
+			),
+
+			// move comparison date and increase current minute
+			5 => array(
+				'current_timestamp' => strtotime( '2017-09-20 09:15:14' ),
+				'compare_timestamp' => strtotime( '2017-09-19 09:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => false,
+			),
+
+			// move comparison date and decrease current minute
+			6 => array(
+				'current_timestamp' => strtotime( '2017-09-20 09:12:14' ),
+				'compare_timestamp' => strtotime( '2017-09-19 09:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => true,
+			),
+
+			// move comparison date and increase current hour
+			7 => array(
+				'current_timestamp' => strtotime( '2017-09-20 10:13:14' ),
+				'compare_timestamp' => strtotime( '2017-09-19 09:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => false,
+			),
+
+			// move comparison date and decrease current hour
+			8 => array(
+				'current_timestamp' => strtotime( '2017-09-20 08:13:14' ),
+				'compare_timestamp' => strtotime( '2017-09-19 09:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => true,
+			),
+
+			// move comparison date, decrease hour and increase current second
+			9 => array(
+				'current_timestamp' => strtotime( '2017-09-20 09:13:14' ),
+				'compare_timestamp' => strtotime( '2017-09-19 08:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => false,
+			),
+
+			// move comparison date, decrease hour and and decrease current second
+			10 => array(
+				'current_timestamp' => strtotime( '2017-09-20 09:13:13' ),
+				'compare_timestamp' => strtotime( '2017-09-19 08:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => false,
+			),
+
+			// move comparison date, decrease hour and and increase current minute
+			11 => array(
+				'current_timestamp' => strtotime( '2017-09-20 09:15:14' ),
+				'compare_timestamp' => strtotime( '2017-09-19 08:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => false,
+			),
+
+			// move comparison date, decrease hour and and decrease current minute
+			12 => array(
+				'current_timestamp' => strtotime( '2017-09-20 09:12:14' ),
+				'compare_timestamp' => strtotime( '2017-09-19 08:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => false,
+			),
+
+			// move comparison date, decrease hour and and increase current hour
+			13 => array(
+				'current_timestamp' => strtotime( '2017-09-20 10:13:14' ),
+				'compare_timestamp' => strtotime( '2017-09-19 08:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => false,
+			),
+
+			// move comparison date, decrease hour and set hour to just outside of 1 day (00:00:00)
+			14 => array(
+				'current_timestamp' => strtotime( '2017-09-20 08:13:14' ),
+				'compare_timestamp' => strtotime( '2017-09-19 08:13:14' ),
+				'start_timestamp'   => strtotime( '2017-09-14 09:13:14' ),
+				'expected_result'   => false,
+			),
+		);
+	}
+
+	/**
+	 * Make sure is_on_same_day() works
+	 *
+	 * @dataProvider provider_is_on_same_day
+	 */
+	public function test_is_on_same_day( $current_timestamp, $compare_timestamp, $start_timestamp, $expected_result ) {
+		$actual_result = WCSR_Resource::is_on_same_day( $current_timestamp, $compare_timestamp, $start_timestamp );
+		$this->assertEquals( $expected_result, $actual_result );
+	}
 }

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -299,7 +299,7 @@ class WCSR_Resource_Test extends PHPUnit_Framework_TestCase {
 			17 => array(
 				'date_created'         => '2017-09-14 09:13:14',
 				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-30 07:00:03', '2017-09-30 09:00:03' ),
-				'deactivation_times'   => array( '2017-09-15 09:13:13', '2017-09-30 08:15:11', '2017-09-30 11:00:03'),
+				'deactivation_times'   => array( '2017-09-15 09:13:13', '2017-09-30 08:15:11', '2017-09-30 11:00:03' ),
 				'expected_days_active' => 3,
 			),
 

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -556,7 +556,20 @@ class WCSR_Resource_Test extends PHPUnit_Framework_TestCase {
 	 * @dataProvider provider_is_on_same_day
 	 */
 	public function test_is_on_same_day( $current_timestamp, $compare_timestamp, $start_timestamp, $expected_result ) {
-		$actual_result = WCSR_Resource::is_on_same_day( $current_timestamp, $compare_timestamp, $start_timestamp );
+		$resource_mock = $this->getMockBuilder( 'WCSR_Resource' )->disableOriginalConstructor()->getMock();
+
+		$actual_result = $this->get_accessible_protected_method( $resource_mock, 'is_on_same_day' )->invoke( $resource_mock, $current_timestamp, $compare_timestamp, $start_timestamp );
 		$this->assertEquals( $expected_result, $actual_result );
+	}
+
+	/**
+	 * A utility function to make certain methods public, useful for testing protected methods
+	 * that affect public APIs, but are not public to avoid use due to potential confusion
+	 */
+	protected function get_accessible_protected_method( $object, $method_name ) {
+		$reflected_object = new ReflectionClass( $object );
+		$reflected_method = $reflected_object->getMethod( $method_name );
+		$reflected_method->setAccessible( true );
+		return $reflected_method;
 	}
 }

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -286,6 +286,74 @@ class WCSR_Resource_Test extends PHPUnit_Framework_TestCase {
 				'deactivation_times'   => array( '2017-09-15 01:15:11' ),
 				'expected_days_active' => 1,
 			),
+
+			/*
+			 * Simulate an new resource that is activated for 1 day at the start, then deactivated until the end of the month, then activated and deactivated across a 4hour period.
+			 * Similar to Test 15, but this test has multiple activations and deactivations at the end of the test and is also active at the beginning.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created for 1 day, then deactivated
+			 * 2. activated for a just under 3 hours across a 4 hour period, then deactivatd for the rest of the cycle
+			 */
+			17 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-30 07:00:03', '2017-09-30 09:00:03' ),
+				'deactivation_times'   => array( '2017-09-15 09:13:13', '2017-09-30 08:15:11', '2017-09-30 11:00:03'),
+				'expected_days_active' => 3,
+			),
+
+			/*
+			 * Simulate an new resource that is activated for 1 day, then deactivated until the end of the month for 4 hours.
+			 * This test is the same as Test 17 (without the multiple activating and deactiving on the same day)
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created for 1 day, then deactivated
+			 * 2. activated for 4 hours at the end of the cycle, then deactivatd for the rest of the cycle
+			 */
+			18 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-30 07:00:03' ),
+				'deactivation_times'   => array( '2017-09-15 09:13:13', '2017-09-30 11:00:03' ),
+				'expected_days_active' => 3,
+			),
+
+			19 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-15 09:12:03', '2017-09-30 09:00:03' ),
+				'deactivation_times'   => array( '2017-09-15 09:00:13', '2017-09-30 08:15:11', '2017-09-30 11:00:03' ),
+				'expected_days_active' => 17,
+			),
+
+			20 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-15 09:12:03', '2017-09-30 09:00:03', '2017-10-01 08:00:03' ),
+				'deactivation_times'   => array( '2017-09-15 09:00:13', '2017-09-30 08:15:11', '2017-09-30 11:00:03', '2017-10-01 10:00:03' ),
+				'expected_days_active' => 18,
+			),
+
+			21 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-15 09:12:03', '2017-09-30 09:00:03', '2017-10-02 08:00:03' ),
+				'deactivation_times'   => array( '2017-09-15 09:00:13', '2017-09-30 08:15:11', '2017-09-30 11:00:03', '2017-10-02 10:00:03' ),
+				'expected_days_active' => 19,
+			),
+
+
+			22 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-15 09:12:03', '2017-09-30 09:00:03', '2017-10-02 09:30:03' ),
+				'deactivation_times'   => array( '2017-09-15 09:00:13', '2017-09-30 08:15:11', '2017-09-30 11:00:03', '2017-10-02 10:00:03' ),
+				'expected_days_active' => 18,
+			),
+
+			23 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-16 09:16:03', '2017-09-30 09:00:03', '2017-10-02 09:30:03' ),
+				'deactivation_times'   => array( '2017-09-15 09:00:13', '2017-09-30 08:15:11', '2017-09-30 11:00:03', '2017-10-02 10:00:03' ),
+				'expected_days_active' => 17,
+			),
 		);
 	}
 

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * Test the WCS_Retry class's public methods
+ */
+class WCSR_Resource_Test extends PHPUnit_Framework_TestCase {
+
+	protected static $from_timestamp;
+
+	protected static $to_timestamp;
+
+	public static function setUpBeforeClass() {
+		self::$from_timestamp = strtotime( '2017-09-14 09:13:14' );
+		self::$to_timestamp   = strtotime( '2017-10-14 09:14:02' );
+	}
+
+	/**
+	 * Provide data to test days active
+	 */
+	public function provider_get_days_active() {
+
+		return array(
+
+			/*
+			 * Simulate a new resource that is active for only the first week during its first cycle.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created
+			 * 2. active for at least 1 second more than 6 * 24 * 60, then deactivated
+			 */
+			0 => array(
+				'date_created'         => '2017-09-14 09:13:14', // same as $from_timestamp
+				'activation_times'     => array( '2017-09-14 09:13:14' ), // same as $from_timestamp
+				'deactivation_times'   => array( '2017-09-20 11:01:40' ),
+				'expected_days_active' => 7,
+			),
+
+			/*
+			 * Simulate an existing active resource that is active for 10 days at the start of its 2nd cycle.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
+			 * 1. activate at the start of the period being checked
+			 * 2. active for at least 1 second more than 9 * 24 * 60 during the period then deactivated
+			 */
+			1 => array(
+				'date_created'         => '2017-08-14 09:13:14', // 1 month prior to $from_timestamp
+				'activation_times'     => array(),
+				'deactivation_times'   => array( '2017-09-23 11:13:40' ),
+				'expected_days_active' => 10,
+			),
+
+			/*
+			 * Simulate an existing inactive resource that is active for 10 days in the middle of its 2nd cycle.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
+			 * 1. first activation timestamp after the start time of the period being checked ($activation_times[0] > $from_timestamp)
+			 * 2. active for at least 1 second more than 9 * 24 * 60 during the period then deactivated
+			 */
+			2 => array(
+				'date_created'         => '2017-08-14 09:13:14', // 1 month prior to $from_timestamp
+				'activation_times'     => array( '2017-09-24 09:13:14' ), // 10 days after $from_timestamp
+				'deactivation_times'   => array( '2017-10-03 11:13:40' ), // 9 days, 2 hours, 26 seconds after activation timestamp
+				'expected_days_active' => 10,
+			),
+
+			/*
+			 * Simulate a new resource that is active for multiple different periods during its first cycle with a total of 10 days.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created
+			 * 2. active for 2 days, then deactivated for 2 days
+			 * 3. active for 2 days, then deactivated for 2 days
+			 * 4. active for 2 days, then deactivated for 2 days
+			 * 5. active for 2 days, then deactivated for 2 days
+			 * 6. activated again for the rest of the cycle
+			 */
+			3 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-18 09:13:14', '2017-09-22 09:13:14', '2017-10-26 09:13:14', '2017-10-30 09:14:02' ),
+				'deactivation_times'   => array( '2017-09-16 09:13:13', '2017-09-20 09:13:13', '2017-09-24 09:13:13', '2017-10-28 09:13:13' ),
+				'expected_days_active' => 6,
+			),
+
+			/*
+			 * Simulate a new resource that is active for multiple different periods during its first cycle with a total of 10 days.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created
+			 * 2. active for at least 1 second more than 4 * 24 * 60, then deactivated
+			 * 3. actived again for at least 1 second more than 4 * 24 * 60, then deactivated before the end of the cycle ($to_timestamp)
+			 */
+			4 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-20 09:13:14' ),
+				'deactivation_times'   => array( '2017-09-18 09:13:15', '2017-09-24 09:13:15' ),
+				'expected_days_active' => 10,
+			),
+
+			/*
+			 * Simulate an existing active resource that is active for multiple different occasions during its 2nd cycle for a total of 10 days.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
+			 * 1. active at the start of the period being checked
+			 * 2. active for at least 1 second more than 4 * 24 * 60, then deactivated
+			 * 3. activated again for at least 1 second more than 4 * 24 * 60, then deactivated before the end of the cycle ($to_timestamp)
+			 */
+			5 => array(
+				'date_created'         => '2017-08-14 09:13:14', // 1 month prior to $from_timestamp
+				'activation_times'     => array( '2017-09-30 09:13:14' ), // previously activated in the last cycle
+				'deactivation_times'   => array( '2017-09-18 10:14:15', '2017-10-04 12:24:10' ),
+				'expected_days_active' => 10,
+			),
+
+			/*
+			 * Simulate an existing inactive resource that is actived for multiple different occasions during its 2nd cycle for a total of 10 days.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
+			 * 1. inactive at the start of the period being checked
+			 * 2. activated for at least 1 second more than 4 * 24 * 60, then deactivated more than 5 * 24 * 60 before the end of the cycle ($to_timestamp)
+			 * 3. activated again for at least 1 second more than 4 * 24 * 60, then deactivated before the end of the cycle ($to_timestamp)
+			 */
+			6 => array(
+				'date_created'         => '2017-08-14 09:13:14', // 1 month prior to $from_timestamp
+				'activation_times'     => array( '2017-09-26 09:13:14', '2017-10-05 09:13:14' ), // previously activated in the last cycle
+				'deactivation_times'   => array( '2017-09-30 15:35:43', '2017-10-09 12:24:10' ),
+				'expected_days_active' => 10,
+			),
+
+			/*
+			 * Simulate a new active resource that is activated and deactivated for multiple occasions on the same day.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created
+			 * 2. activated for just over an hour, then deactivated for 2'ish hours
+			 * 3. activated 4 hours then deactivated for the rest of the cycle
+			 */
+			7 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-14 13:13:14' ),
+				'deactivation_times'   => array( '2017-09-14 10:35:43', '2017-09-14 17:24:10' ),
+				'expected_days_active' => 1,
+			),
+
+			/*
+			 * Simulate a new active resource that is active for the full cycle
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 */
+			8 => array(
+				'date_created'         => '2017-09-14 09:13:14', // same as $from_timestamp
+				'activation_times'     => array( '2017-09-14 09:13:14' ),
+				'deactivation_times'   => array(),
+				'expected_days_active' => 31,
+			),
+
+			/*
+			 * Simulate an existing active resource that is active for full cycle
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
+			 * 1. active before the start of the period being checked
+			 */
+			9 => array(
+				'date_created'         => '2017-08-14 09:13:14',
+				'activation_times'     => array(),
+				'deactivation_times'   => array(),
+				'expected_days_active' => 31,
+			),
+
+			/*
+			 * Simulate a new active resource that is activated and deactivated for multiple occasions on the same day and then left active for 2 days.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created
+			 * 2. activated for just over an hour, then deactivated for 2'ish hours
+			 * 3. activated 4 hours then deactivated for the rest of the cycle
+			 */
+			10 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-14 13:13:14', '2017-09-14 20:00:03' ),
+				'deactivation_times'   => array( '2017-09-14 10:35:43', '2017-09-14 17:24:10', '2017-09-16 17:24:10' ),
+				'expected_days_active' => 2,
+			),
+		);
+	}
+
+	/**
+	 * Make sure get_days_active() handles all calculation scenarios
+	 *
+	 * @dataProvider provider_get_days_active
+	 */
+	public function test_get_days_active( $date_created_string, $activation_times, $deactivation_times, $expected_days_active ) {
+
+		$date_created = new DateTime();
+		$date_created->setTimestamp( strtotime( $date_created_string ) );
+
+		// Convert activation/deactivate dates to timestamps
+		$activation_times   = array_map( 'strtotime', $activation_times );
+		$deactivation_times = array_map( 'strtotime', $deactivation_times );
+
+		$resource_mock = $this->getMockBuilder( 'WCSR_Resource' )->setMethods( array( 'get_date_created', 'has_been_activated', 'get_activation_timestamps', 'get_deactivation_timestamps' ) )->disableOriginalConstructor()->getMock();
+		$resource_mock->expects( $this->any() )->method( 'get_date_created' )->will( $this->returnValue( $date_created ) );
+		$resource_mock->expects( $this->any() )->method( 'has_been_activated' )->will( $this->returnValue( true ) );
+		$resource_mock->expects( $this->any() )->method( 'get_activation_timestamps' )->will( $this->returnValue( $activation_times ) );
+		$resource_mock->expects( $this->any() )->method( 'get_deactivation_timestamps' )->will( $this->returnValue( $deactivation_times ) );
+
+		$this->assertEquals( $expected_days_active, $resource_mock->get_days_active( self::$from_timestamp, self::$to_timestamp ) );
+	}
+}

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -189,8 +189,87 @@ class WCSR_Resource_Test extends PHPUnit_Framework_TestCase {
 				'date_created'         => '2017-09-14 09:13:14',
 				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-14 13:13:14', '2017-09-14 20:00:03' ),
 				'deactivation_times'   => array( '2017-09-14 10:35:43', '2017-09-14 17:24:10', '2017-09-16 17:24:10' ),
-				'expected_days_active' => 2,
 				'expected_days_active' => 3,
+			),
+
+			/*
+			 * Simulate a new active resource that is activated and deactivated for multiple occasions on the same day and then left active for the rest of the month.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created
+			 * 2. activated for just over an hour, then deactivated for 2'ish hours
+			 * 3. activated for the rest of the cycle
+			 */
+			11 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-14 13:13:14', '2017-09-14 20:00:03' ),
+				'deactivation_times'   => array( '2017-09-14 10:35:43', '2017-09-14 17:24:10' ),
+				'expected_days_active' => 31,
+			),
+
+			/*
+			 * Simulate a new active resource that is activated and deactivated for multiple occasions on the same day and then left inactive for the rest of the month.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created
+			 * 2. activated for just over an hour, then deactivated for 2'ish hours
+			 * 3. activated 4 hours then deactivated for the rest of the period
+			 */
+			12 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-14 13:13:14' ),
+				'deactivation_times'   => array( '2017-09-14 10:35:43', '2017-09-14 17:24:10' ),
+				'expected_days_active' => 1,
+			),
+
+			/*
+			 * Simulate a new active resource that is activated and deactivated for multiple occasions everyday for 3 days and then left inactive for the rest of the month.
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created
+			 * 2. activated for just over an hour, then deactivated for 2'ish hours
+			 * 3. activated 4 hours then deactivated for the rest of the period
+			 */
+			13 => array(
+				'date_created'         => '2017-09-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 09:13:14', '2017-09-14 13:13:14', '2017-09-15 09:13:14', '2017-09-15 13:13:14', '2017-09-16 09:13:14', '2017-09-16 13:13:14' ),
+				'deactivation_times'   => array( '2017-09-14 10:35:43', '2017-09-14 17:24:10', '2017-09-15 10:35:43', '2017-09-15 17:24:10', '2017-09-16 10:35:43', '2017-09-16 17:24:10' ),
+				'expected_days_active' => 3,
+			),
+
+			/*
+			 * Simulate an existing resource that is activated roughly 12 hours into the first day then left activated
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created
+			 * 2. activated for just over an hour, then deactivated for 2'ish hours
+			 * 3. activated for the rest of the cycle
+			 */
+			14 => array(
+				'date_created'         => '2017-08-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 20:00:03' ),
+				'deactivation_times'   => array(),
+				'expected_days_active' => 30,
+			),
+
+			/*
+			 * Simulate an existing resource that is activated for 1 hour into the first day then left activated
+			 *
+			 * To test this requires a resource that is:
+			 * 0. created at the same time as the start of the period being checked ($from_timestamp)
+			 * 1. activate at the time it is created
+			 * 2. activated for just over an hour, then deactivated for 2'ish hours
+			 * 3. activated for the rest of the cycle
+			 */
+			15 => array(
+				'date_created'         => '2017-06-14 09:13:14',
+				'activation_times'     => array( '2017-09-14 20:00:03', '2017-09-14 22:00:03' ),
+				'deactivation_times'   => array( '2017-09-14 21:00:03', '2017-09-15 01:15:11' ),
+				'expected_days_active' => 1,
 			),
 		);
 	}


### PR DESCRIPTION
Props to @thenbrent for the core of the fix and also for writing up the test cases RE: https://github.com/Prospress/woocommerce-subscriptions-resource/issues/11#issuecomment-339161413

Additional changes and fixes from made to the code since that comment:
 - Fixed an issue where if the first activation timestamp comes after the first deactivation date. In other words, if the resource was activated in a previous cycle, and then only deactivated in the current cycle, we need to make sure we append the start timestamp to act as the first "activated" date for the resource. This was fixed by adding [these lines](https://github.com/Prospress/woocommerce-subscriptions-resource/blob/9a6b547d644119e4ad4fc699198b044eaa880aaa/includes/class-wcsr-resource.php#L192-L195)
 - Added additional handling for when the resource is activated and deactivated multiple times on the same day. Fixed with 9a6b547. I wrote two test cases for this scenario which can be found in the code below if you search for `Resource 8` and `Resource 11`.
 - couple more test cases including testing a full month of having a resource active
 - two different cases for activating and deactivating a resource multiple times on the same day

---

To test this I used Brents test code provided in #11 and with it comes 11 different test cases
Link to gist plugin: https://gist.github.com/mattallan/7695a3ff681bf3ba0e0080f2bb8617ad

```
function test_get_days_active() {

 	error_log( '----' );
 	error_log( '----' );
 	error_log( '----' );

 	$from_timestamp = strtotime( '2017-09-14 09:13:14' );
 	$to_timestamp   = strtotime( '2017-10-14 09:14:02' );

 	/*
 	 * Simulate a new resource that is active for only the first week during its first cycle.
 	 *
 	 * To test this requires a resource that is:
 	 * 0. created at the same time as the start of the period being checked ($from_timestamp)
 	 * 1. activate at the time it is created
 	 * 2. active for at least 1 second more than 6 * 24 * 60, then deactivated
 	 */
 	$resource_creation_time      = strtotime( '2017-09-14 09:13:14' ); // same as $from_timestamp
 	$resource_activation_times   = array( strtotime( '2017-09-14 09:13:14' ) ); // same as $from_timestamp
 	$resource_deactivation_times = array( strtotime( '2017-09-20 11:01:40' ) );

 	$days_active = eg_get_days_active( $from_timestamp, $to_timestamp, $resource_activation_times, $resource_deactivation_times, $resource_creation_time );
 	error_log( '---- Resource 1 has been active for: ' . $days_active . ' days. Should be 7 days.' );


 	/*
 	 * Simulate an existing active resource that is active for 10 days at the start of its 2nd cycle.
 	 *
 	 * To test this requires a resource that is:
 	 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
 	 * 1. activate at the start of the period being checked
 	 * 2. active for at least 1 second more than 9 * 24 * 60 during the period then deactivated
 	 */
 	$resource_creation_time      = strtotime( '2017-08-14 09:13:14' ); // 1 month prior to $from_timestamp
 	$resource_activation_times   = array(); // activated prior to $from_timestamp, not reactivated during this period after it was deactivated
 	$resource_deactivation_times = array( strtotime( '2017-09-23 11:13:40' ) ); // 9 days, 2 hours, 26 seconds after $from_timestamp

 	$days_active = eg_get_days_active( $from_timestamp, $to_timestamp, $resource_activation_times, $resource_deactivation_times, $resource_creation_time );
 	error_log( '---- Resource 2 has been active for: ' . $days_active . ' days. Should be 10 days.' );


 	/*
 	 * Simulate an existing inactive resource that is active for 10 days in the middle of its 2nd cycle.
 	 *
 	 * To test this requires a resource that is:
 	 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
 	 * 1. first activation timestamp after the start time of the period being checked ($activation_times[0] > $from_timestamp)
 	 * 2. active for at least 1 second more than 9 * 24 * 60 during the period then deactivated
 	 */
 	$resource_creation_time      = strtotime( '2017-08-14 09:13:14' ); // 1 month prior to $from_timestamp
 	$resource_activation_times   = array( strtotime( '2017-09-24 09:13:14' ) ); // 10 days after $from_timestamp
 	$resource_deactivation_times = array( strtotime( '2017-10-03 11:13:40' ) ); // 9 days, 2 hours, 26 seconds after activation timestamp

 	$days_active = eg_get_days_active( $from_timestamp, $to_timestamp, $resource_activation_times, $resource_deactivation_times, $resource_creation_time );
 	error_log( '---- Resource 3 has been active for: ' . $days_active . ' days. Should be 10 days.' );

	/*
 	 * Simulate a new resource that is active for multiple different periods during its first cycle with a total of 10 days.
 	 *
 	 * To test this requires a resource that is:
 	 * 0. created at the same time as the start of the period being checked ($from_timestamp)
 	 * 1. activate at the time it is created
 	 * 2. active for 2 days exactly, then deactivated for 4 days
	 * 3. active for 2 days exactly, then deactivated for 3 days
	 * 4. active for 2 days exactly, then deactivated for 7 days
	 * 5. active for 2 days exactly, then deactivated for 6 days
 	 * 6. activated again for the rest of the cycle
 	 */
	$resource_creation_time      = strtotime( '2017-09-14 09:13:14' );
	$resource_activation_times   = array( strtotime( '2017-09-14 09:13:14' ), strtotime( '2017-09-20 09:13:14' ), strtotime( '2017-09-25 09:13:14' ), strtotime( '2017-10-04 09:13:14' ), strtotime( '2017-10-12 09:14:02' ) );
	$resource_deactivation_times = array( strtotime( '2017-09-16 09:13:14' ), strtotime( '2017-09-22 09:13:14' ), strtotime( '2017-09-27 09:13:14' ), strtotime( '2017-10-06 09:13:14' ) );

	$days_active = eg_get_days_active( $from_timestamp, $to_timestamp, $resource_activation_times, $resource_deactivation_times, $resource_creation_time );
	error_log( '---- Resource 4 has been active for: ' . $days_active . ' days. Should be 10 days.' );

 	/*
 	 * Simulate a new resource that is active for multiple different periods during its first cycle with a total of 10 days.
 	 *
 	 * To test this requires a resource that is:
 	 * 0. created at the same time as the start of the period being checked ($from_timestamp)
 	 * 1. activate at the time it is created
 	 * 2. active for at least 1 second more than 4 * 24 * 60, then deactivated
 	 * 3. actived again for at least 1 second more than 4 * 24 * 60, then deactivated before the end of the cycle ($to_timestamp)
 	 */
	$resource_creation_time      = strtotime( '2017-09-14 09:13:14' );
	$resource_activation_times   = array( strtotime( '2017-09-14 09:13:14' ), strtotime( '2017-09-20 09:13:14' ) );
	$resource_deactivation_times = array( strtotime( '2017-09-18 09:13:15' ), strtotime( '2017-09-24 09:13:15' ) );

	$days_active = eg_get_days_active( $from_timestamp, $to_timestamp, $resource_activation_times, $resource_deactivation_times, $resource_creation_time );
	error_log( '---- Resource 5 has been active for: ' . $days_active . ' days. Should be 10 days.' );

 	/*
 	 * Simulate an existing active resource that is active for multiple different occasions during its 2nd cycle for a total of 10 days.
 	 *
 	 * To test this requires a resource that is:
 	 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
 	 * 1. active at the start of the period being checked
 	 * 2. active for at least 1 second more than 4 * 24 * 60, then deactivated
 	 * 3. activated again for at least 1 second more than 4 * 24 * 60, then deactivated before the end of the cycle ($to_timestamp)
 	 */
	 $resource_creation_time      = strtotime( '2017-08-14 09:13:14' ); // 1 month prior to $from_timestamp
	 $resource_activation_times   = array( strtotime( '2017-09-30 09:13:14' ) ); // previously activated in the last cycle
	 $resource_deactivation_times = array( strtotime( '2017-09-18 10:14:15' ), strtotime( '2017-10-04 12:24:10' ) );

	 $days_active = eg_get_days_active( $from_timestamp, $to_timestamp, $resource_activation_times, $resource_deactivation_times, $resource_creation_time );
	 error_log( '---- Resource 6 has been active for: ' . $days_active . ' days. Should be 10 days.' );

	/*
	 * Simulate an existing active resource that is active for multiple different occasions during its 2nd cycle for a total of 10 days.
	 *
	 * To test this requires a resource that is:
	 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
	 * 1. inactive at the start of the period being checked
	 * 2. activated for at least 1 second more than 4 * 24 * 60, then deactivated more than 5 * 24 * 60 before the end of the cycle ($to_timestamp)
	 * 3. activated again for at least 1 second more than 4 * 24 * 60, then deactivated before the end of the cycle ($to_timestamp)
	 */
	$resource_creation_time      = strtotime( '2017-08-14 09:13:14' ); // 1 month prior to $from_timestamp
	$resource_activation_times   = array( strtotime( '2017-09-26 09:13:14' ), strtotime( '2017-10-05 09:13:14' ) ); // previously activated in the last cycle
	$resource_deactivation_times = array( strtotime( '2017-09-30 15:35:43' ), strtotime( '2017-10-09 12:24:10' ) );

 	$days_active = eg_get_days_active( $from_timestamp, $to_timestamp, $resource_activation_times, $resource_deactivation_times, $resource_creation_time );
 	error_log( '---- Resource 7 has been active for: ' . $days_active . ' days. Should be 10 days.' );

	/*
	 * Simulate a new active resource that is activated and deactivated for multiple occasions on the same day.
	 *
	 * To test this requires a resource that is:
	 * 0. created at the same time as the start of the period being checked ($from_timestamp)
 	 * 1. activate at the time it is created
	 * 2. activated for just over an hour, then deactivated for 2'ish hours
	 * 3. activated 4 hours then deactivated for the rest of the cycle
	 */
	$resource_creation_time      = strtotime( '2017-09-14 09:13:14' );
	$resource_activation_times   = array( strtotime( '2017-09-14 09:13:14' ), strtotime( '2017-09-14 13:13:14' ) );
	$resource_deactivation_times = array( strtotime( '2017-09-14 10:35:43' ), strtotime( '2017-09-14 17:24:10' ) );

	$days_active = eg_get_days_active( $from_timestamp, $to_timestamp, $resource_activation_times, $resource_deactivation_times, $resource_creation_time );
 	error_log( '---- Resource 8 has been active for: ' . $days_active . ' days. Should be 1 days.' );

	/*
	 * Simulate a new active resource that is active for the full cycle
	 *
	 * To test this requires a resource that is:
	 * 0. created at the same time as the start of the period being checked ($from_timestamp)
	 */
	$resource_creation_time      = strtotime( '2017-09-14 09:13:14' ); // same as from timestamp
	$resource_activation_times   = array( strtotime( '2017-09-14 09:13:14' ) ); // same as from timestamp
	$resource_deactivation_times = array();

	$days_active = eg_get_days_active( $from_timestamp, $to_timestamp, $resource_activation_times, $resource_deactivation_times, $resource_creation_time );
	error_log( '---- Resource 9 has been active for: ' . $days_active . ' days. Should be 31 days.' );

	/*
	 * Simulate an existing active resource that is active for full cycle
	 *
	 * To test this requires a resource that is:
	 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
	 * 1. active before the start of the period being checked
	 */
	$resource_creation_time      = strtotime( '2017-08-14 09:13:14' ); // 1 month prior to $from_timestamp
	$resource_activation_times   = array(); // no activation times fall between the from and to timestamps
	$resource_deactivation_times = array(); // no deactivation times fall between the from and to timestamps

	$days_active = eg_get_days_active( $from_timestamp, $to_timestamp, $resource_activation_times, $resource_deactivation_times, $resource_creation_time );
	error_log( '---- Resource 10 has been active for: ' . $days_active . ' days. Should be 31 days.' );

	/*
	 * Simulate a new active resource that is activated and deactivated for multiple occasions on the same day and then left active for 2 days.
	 *
	 * To test this requires a resource that is:
	 * 0. created at the same time as the start of the period being checked ($from_timestamp)
	 * 1. activate at the time it is created
	 * 2. activated for just over an hour, then deactivated for 2'ish hours
	 * 3. activated 4 hours then deactivated for the rest of the cycle
	 */
	$resource_creation_time      = strtotime( '2017-09-14 09:13:14' );
	$resource_activation_times   = array( strtotime( '2017-09-14 09:13:14' ), strtotime( '2017-09-14 13:13:14' ), strtotime( '2017-09-14 20:00:03' ) );
	$resource_deactivation_times = array( strtotime( '2017-09-14 10:35:43' ), strtotime( '2017-09-14 17:24:10' ), strtotime( '2017-09-16 17:24:10' ) );

	$days_active = eg_get_days_active( $from_timestamp, $to_timestamp, $resource_activation_times, $resource_deactivation_times, $resource_creation_time );
	error_log( '---- Resource 11 has been active for: ' . $days_active . ' days. Should be 2 days.' );

}
add_action( 'admin_init', 'test_get_days_active' );

function eg_get_days_active( $from_timestamp, $to_timestamp, $activation_times, $deactivation_times, $resource_created_time ) {
	$days_active = 0;

	// if the first activation date in the array comes after the first deactivation date, make sure we append the $from_timestamp as the first "activated" date
	if ( ! isset( $activation_times[0] ) || ( isset( $deactivation_times[0] ) && $activation_times[0] > $deactivation_times[0] ) ) {
		$start_timestamp = ( $resource_created_time > $from_timestamp ) ? $resource_created_time : $from_timestamp;
		array_unshift( $activation_times, $start_timestamp );
	}

	foreach ( $activation_times as $i => $activation_time ) {
		// If there is corresponding deactivation timestamp, the resouce has deactivated before the end of the period so that's the time we want, otherwise, use the end of the period as the resource was still active at end of the period
		$deactivation_time = isset( $deactivation_times[ $i ] ) ? $deactivation_times[ $i ] : $to_timestamp;

		// skip over any days that are activated/deactivated on the same day and have already been accounted for
		if ( $i !== 0 && gmdate( 'Y-m-d', $deactivation_times[--$i] ) == gmdate( 'Y-m-d', $deactivation_time ) ) {
			continue;
		}

		$days_active += absint( ceil( ( $deactivation_time - $activation_time ) / DAY_IN_SECONDS ) );

		// if the activation date is the same as the previous activation date, minus one off one day active from the result since the day was already accounted for previously
		if ( $i !== 0 && gmdate( 'Y-m-d', $activation_times[--$i] ) == gmdate( 'Y-m-d', $activation_times[$i] ) ) {
			$days_active -= 1;
		}
	}

	return $days_active;
}
```