### PR TITLE
Make sure the days active isn't more than the days in period

### DIFF
--- a/includes/class-wcsr-resource-manager.php
+++ b/includes/class-wcsr-resource-manager.php
@@ -140,6 +140,12 @@ class WCSR_Resource_Manager {
 					// Calculate the usage and the ratio of active days vs days in the period
 					$days_active       = $resource->get_days_active( $from_timestamp, $to_timestamp );
 					$days_in_period    = wcsr_get_days_in_period( $from_timestamp, $to_timestamp );
+
+					// make sure the days active doesn't go over the amount of days in the period
+					if ( $days_active > $days_in_period ) {
+						$days_active = $days_in_period;
+					}
+
 					$days_active_ratio = wcsr_get_active_days_ratio( $from_timestamp, $days_in_period, $days_active, $subscription->get_billing_period(), $subscription->get_billing_interval() );
 
 					foreach ( $line_items as $line_item ) {

--- a/tests/unit/class-wcsr-time-functions-test.php
+++ b/tests/unit/class-wcsr-time-functions-test.php
@@ -223,6 +223,26 @@ class WCSR_Time_Functions_Test extends WCSR_Unit_TestCase {
 				'billing_interval' => 1,
 				'expected_ratio'  => 0.99
 			),
+
+			// Jason's renewal test case - 12 day period, 13 days active, the ratio should account for 12 days because thats the days in period
+			21 => array(
+				'from_timestamp'   => '2017-09-14 14:21:40',
+				'days_in_period'   => 12,
+				'days_active'      => 13,
+				'billing_period'   => 'month',
+				'billing_interval' => 1,
+				'expected_ratio'   => 0.4
+			),
+
+			// 32 days active in a 31 days period from August (full month) - this test is not possible now that we have a safe guard so that the active days is never more than the days in period
+			22 => array(
+				'from_timestamp'   => '2017-08-14 14:21:40',
+				'days_in_period'   => 31,
+				'days_active'      => 32,
+				'billing_period'   => 'month',
+				'billing_interval' => 1,
+				'expected_ratio'   => 1
+			),
 		);
 	}
 


### PR DESCRIPTION
Fixes #22 

This small PR is merging into `issue_15`, so feel free to merge https://github.com/Prospress/woocommerce-subscriptions-resource/pull/16 first and then i'll rebase this one off master.

---

There was a few cases where the line items just didn't look right, i.e:
 - `usage for 32 days in 31 days` (line item total would be for 31 days)
 - `usage for 13 days in 12 days.` (line item total would be for 12 days)

IMO the line item totals are correct, so the thing that needs to change is the usage days (days active) so that it doesn't go over the days in period.

On the issue (see #22) and in slack, i listed two alternative approaches, but the fix I went with was to just simply make sure the days active is not more than the days in period. If it is, make sure we set the days active as the days in period.

The reason for going with this approach is because the other approach (of using the ceil value if the days in period is less than the billing period) would mean we may sometimes charge for the same day twice.

If we take the second example above. The monthly subscription was renewed early, and there was only 12 days in the period, but 13 were active. If we charged 13 days, then the next time it renews the last day of the previous cycle (13th active day) and the first day of the next cycle would be essentially double charged.

In this PR i've also attached a couple more unit tests that I [mentioned in slack](https://prospress.slack.com/archives/C1QQF18V7/p1511548911000250?thread_ts=1511485073.000012&cid=C1QQF18V7). The 20th test is the one that replicates Jason's renewal of $3.60 line item totals.