### PR TITLE
Fix the incorrect active days ratio calculation when days in period is less than the billing cycle on the subscription

### DIFF
--- a/includes/wcsr-time-functions.php
+++ b/includes/wcsr-time-functions.php
@@ -57,15 +57,8 @@ function wcsr_get_active_days_ratio( $from_timestamp, $days_in_period, $days_act
 	if ( $days_active >= $days_in_period ) {
 		$active_days_ratio = $number_of_billing_periods;
 	} else {
-		// If there are more extra days in this cycle, then either the subscription has been suspended for one or more payments, or the more recent renewal order/s may have failed and the subscription has been manually reactivated, so we need to remove the extra days in the period to account for the extra days to make sure the ratio used to determine daily rates reflects the increased time period.
-		$extra_days_in_cycle = $days_in_period - ( $days_in_billing_cycle / $number_of_billing_periods );
-
-		// now that we have the exact amount of days in the billing cycle, we don't need to account for 2 days like the code example given in https://github.com/Prospress/woocommerce-subscriptions-resource/pull/16#issuecomment-344707347
-		if ( $extra_days_in_cycle >= 0 ) {
-			$days_in_period -= $extra_days_in_cycle;
-		}
-
-		$active_days_ratio = round( $days_active / $days_in_period, 2 );
+		// calculate the active days ratio for days active and days in period, then multiply that by the number of billing periods found between the from and to timestamp. This replaces the extra days in cycle logic because instead of finding the extra days and minusing that off the days in period, we can just multiply the result by the number of cycles.
+		$active_days_ratio = round( ( $days_active / $days_in_period ) * $number_of_billing_periods, 2 );
 	}
 
 	return $active_days_ratio;

--- a/tests/unit/class-wcsr-time-functions-test.php
+++ b/tests/unit/class-wcsr-time-functions-test.php
@@ -203,6 +203,26 @@ class WCSR_Time_Functions_Test extends WCSR_Unit_TestCase {
 				'billing_interval' => 1,
 				'expected_ratio'  => 0 // the renewal came late so they should be charged 1 month + 1 day.
 			),
+
+			// monthly subscription, 17 day in period, 15 days active
+			19 => array(
+				'from_timestamp'   => '2017-11-11 10:24:40',
+				'days_in_period'   => 17,
+				'days_active'      => 15,
+				'billing_period'   => 'month',
+				'billing_interval' => 1,
+				'expected_ratio'  => 0.5 // For Jasons recent renewal and prior the latest changes, this value was returning 0.88 as the days active ratio and the result from the line item 0.88 * $9.00 = $7.92
+			),
+
+			// a simple test to confirm the logic for minusing off the extra days can be replaced by: ( $days_active / $days_in_period ) * $number_of_billing_periods
+			20 => array(
+				'from_timestamp'   => '2017-09-14 10:24:40',
+				'days_in_period'   => 170, // just short of 6 months - extra days would've been ~140
+				'days_active'      => 30,
+				'billing_period'   => 'month',
+				'billing_interval' => 1,
+				'expected_ratio'  => 0.99
+			),
 		);
 	}
 


### PR DESCRIPTION
Keeping this small fix separate to avoid push it to the already big changeset on `issue_15`.

This patch is being merged into `issue_15` so feel free to merge this first or continue reviewing `issue_15` and then merge this one in after.

See slack for report and screenshot of order items: https://prospress.slack.com/archives/C1QQF18V7/p1513028809000719

> Bunch of stores running for 18 days billed $5.13.
> 1 store running for 15 days billed $7.92.
> Because it was only started partway through the billing period I suspect its calculating off 17.04 days total or something like maybe.

Heres the values used in the calculation of active days:
 - days in period was 17
 - days active as 15
 - number of billing periods was 0.57 (17/30 round2)

The bunch of stores that were charged 5.13 is correct, they were active for the entire 17 days in the period so `0.57 * $9.00` = $5.13

The one store that was billed $7.92 for 15 days is incorrect.

Whats happening here it's calculating the active days ratio as 0.88 - `15 day active / 17 days in period`. 0.88 * 9 = 7.92

---

The fix is to calculate the days active against the days ratio and then multiply that by the number of billing periods found between the from and to timestamp.

So whats happening now is 15/17 * 0.57 = 0.5 ✅ 15 days in a monthly subscription period should be charged $4.50 (unless i'm mistaken)

---

I've added more unit tests.
 1. which tests the exact case that happened on Jason's renewal (see slack discussion). If you copy the test over to master, you'll get 0.88 (which is wrong)
 2. another test which makes sure the logic around extra days in correct (if you copy this over to master you'll see a slight discrepancy between the expected ratios (one will be .99 and another 0.93) but this is just a rounding issue and is both working as intended.