### PR TITLE
Is Active function.

### DIFF
--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -205,8 +205,9 @@ class WCSR_Resource extends WC_Data {
 		$activation_times   = wcsr_get_timestamps_between( $this->get_activation_timestamps(), $from_timestamp, $to_timestamp );
 		$deactivation_times = wcsr_get_timestamps_between( $this->get_deactivation_timestamps(), $from_timestamp, $to_timestamp );
 
-		// if the first activation date is after the first deactivation date, make sure we prepend the start timestamp to act as the first "activated" date for the resource
-		if ( ! isset( $activation_times[0] ) || ( isset( $deactivation_times[0] ) && $activation_times[0] > $deactivation_times[0] ) ) {
+		// if the the first activation time isset and comes after the first deactivation time, make sure we prepend the start timestamp to act as the first "activated" date for the resource
+		// if the resource was active at $from_timestamp but doesn't have a first activation time, make sure we prepend the start timestamp to act as the first "activated" date for the resource
+		if ( ( $this->is_active( $from_timestamp ) && ! isset( $activation_times[0] ) || ( isset( $activation_times[0] ) && isset( $deactivation_times[0] ) && $activation_times[0] > $deactivation_times[0] ) ) ) {
 			$start_timestamp = ( $this->get_date_created()->getTimestamp() > $from_timestamp ) ? $this->get_date_created()->getTimestamp() : $from_timestamp;
 
 			// before setting the start timestamp as the created time or the $from_timestamp make sure the deactivation date doesn't come before it

--- a/includes/class-wcsr-resource.php
+++ b/includes/class-wcsr-resource.php
@@ -263,6 +263,42 @@ class WCSR_Resource extends WC_Data {
 	}
 
 	/**
+	 * Based on a resource's activation and deactivation timestamps, determine if the resource is active.
+	 *
+	 * If a timestamp is given, this function will determine if the resource was active at a given time.
+	 *
+	 * @param int $at_timestamp
+	 * @return bool
+	 */
+	public function is_active( $at_timestamp = 0 ) {
+		$is_active = false;
+		$timestamp = ( empty( $at_timestamp ) ) ? time() : $at_timestamp;
+
+		if ( empty( $timestamp ) || false === $this->has_been_activated() ) {
+			return $is_active;
+		}
+
+		$activation_times   = $this->get_activation_timestamps();
+		$deactivation_times = $this->get_deactivation_timestamps();
+
+		foreach ( $activation_times as $i => $activation_time ) {
+			$deactivation_time = isset( $deactivation_times[ $i ] ) ? $deactivation_times[ $i ] : null;
+
+			if ( ! empty( $deactivation_time ) && ( $timestamp >= $activation_time ) && ( $timestamp < $deactivation_time ) ) {
+				$is_active = true;
+				break;
+			}
+
+			if ( empty( $deactivation_time ) && ( $timestamp >= $activation_time ) ) {
+				$is_active = true;
+				break;
+			}
+		}
+
+		return $is_active;
+	}
+
+	/**
 	 * Setters
 	 */
 

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -46,7 +46,7 @@ class WCSR_Resource_Test extends WCSR_Unit_TestCase {
 			 */
 			1 => array(
 				'date_created'         => '2017-08-14 09:13:14', // 1 month prior to $from_timestamp
-				'activation_times'     => array(),
+				'activation_times'     => array( '2017-08-14 09:13:14' ),
 				'deactivation_times'   => array( '2017-09-23 11:13:40' ),
 				'expected_days_active' => 10,
 			),
@@ -163,7 +163,7 @@ class WCSR_Resource_Test extends WCSR_Unit_TestCase {
 			),
 
 			/*
-			 * Simulate an existing active resource that is active for full cycle
+			 * Simulate a resource that has never been activated or deactivated
 			 *
 			 * To test this requires a resource that is:
 			 * 0. created prior to the start of the period being checked ($creation_time < $from_timestamp)
@@ -173,7 +173,7 @@ class WCSR_Resource_Test extends WCSR_Unit_TestCase {
 				'date_created'         => '2017-08-14 09:13:14',
 				'activation_times'     => array(),
 				'deactivation_times'   => array(),
-				'expected_days_active' => 31,
+				'expected_days_active' => 0,
 			),
 
 			/*

--- a/tests/unit/class-wcsr-resource-test.php
+++ b/tests/unit/class-wcsr-resource-test.php
@@ -459,6 +459,14 @@ class WCSR_Resource_Test extends WCSR_Unit_TestCase {
 				'deactivation_times'   => array( '2017-09-01 09:13:14' ),
 				'expected_days_active' => 25,
 			),
+
+			// Tests for having 0 days active
+			34 => array(
+				'date_created'         => '2017-08-14 09:13:14',
+				'activation_times'     => array( '2017-08-14 09:13:14' ),
+				'deactivation_times'   => array( '2017-08-15 09:13:14' ),
+				'expected_days_active' => 0,
+			),
 		);
 	}
 

--- a/tests/unit/class-wcsr-time-functions-test.php
+++ b/tests/unit/class-wcsr-time-functions-test.php
@@ -243,6 +243,16 @@ class WCSR_Time_Functions_Test extends WCSR_Unit_TestCase {
 				'billing_interval' => 1,
 				'expected_ratio'   => 1
 			),
+
+			// 0 days active days active
+			23 => array(
+				'from_timestamp'   => '2017-08-14 14:21:40',
+				'days_in_period'   => 31,
+				'days_active'      => 0,
+				'billing_period'   => 'month',
+				'billing_interval' => 1,
+				'expected_ratio'   => 0
+			),
 		);
 	}
 


### PR DESCRIPTION
Props @jconroy.

A few things:
 1. 0565e9a Adds a `is_active()` function which is a little more generic then Jason's first copy (based on this mornings RN call). Code is exactly the same but just one added line so that it allows the function to be called without a timestamp param which will check if the resource is currently active, or with a given timestamp to check if the resource was active at a specific time.
 2. 808b82b Updates the logic in `get_active_days()` to make sure we only add `activation_timestamps[0]` if it's active
 3. The new logic in `get_active_days()` broke some of the existing tests. See c79ddd5 commit message for more details on why they were broken and what needed to be changed.
4. I've added a handful of unit tests for testing `$resource->is_active()` as well as adding some more tests for checking if get_active_days returns 0.