### PR TITLE
Manually load the WC_DateTime class in test suite bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,6 +62,11 @@ class WCSR_Unit_Tests_Bootstrap {
 		// Load WooCommerce Subscription files
 		require_once( $this->modules_dir . '/woocommerce-subscriptions/includes/wcs-time-functions.php' );
 
+		// Manually Load WC_DateTime during test suite
+		if ( ! class_exists( 'WC_DateTime' ) ) {
+			require_once( $this->modules_dir . '/woocommerce-subscriptions/includes/libraries/class-wc-datetime.php' );
+		}
+
 		// Load relevant class aliases for PHPUnit 6 (ran on PHP v7.0+ in Travis)
 		if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner\Version::id(), '6.0', '>=' ) ) {
 			class_alias( 'PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase' );


### PR DESCRIPTION
Fixes #28 
Subscriptions recently changed their wcs_time functions to use `WC_DateTime` class instead of default PHP datetime class: https://github.com/Prospress/woocommerce-subscriptions/commit/e13a06d74990686766136658c33a96f18fdb67f8#diff-3ba199718cad858b21a9b14a1ac837f9

To fix this, we just need to make sure the class is manually loaded during tests by adding it to the `tests/bootstrap.php` file.

We could load all the Subscription classes (including the WC_DateTime) by calling something like `WC_Subscriptions::load_dependant_classes()` but that feels like overkill for the resource unit tests.