### PR TITLE
Add a new hook to filter the individual prorated line item for the resource

### DIFF
--- a/includes/class-wcsr-resource-manager.php
+++ b/includes/class-wcsr-resource-manager.php
@@ -154,6 +154,8 @@ class WCSR_Resource_Manager {
 						$new_item = wcsr_get_prorated_line_item( $line_item, $days_active_ratio );
 						$new_item->set_name( wcsr_get_line_item_name( $new_item, $days_active, $days_in_period, $resource, $from_timestamp, $to_timestamp ) );
 
+						$new_item = apply_filters( 'wcsr_prorated_line_item_for_resource', $new_item, $resource );
+
 						// Add item to order
 						$renewal_order->add_item( $new_item );
 


### PR DESCRIPTION
The `WCSR_Resource_Manager::maybe_prorate_renewal()` function doesn't have any hook available to filter the prorated line items being added to the renewal order.

For Robot Ninja we need to filter each prorated line item based on the external object (store) linked to the resource before it's added to the renewal order.

This PR is just a small'y and adds the new filter `wcsr_prorated_line_item_for_resource` and passes the `$new_item` item and the `$resource` object.

The alternative approach I was thinking was to pass the `$resource` object to [`wcsr_get_prorated_line_item()`](https://github.com/Prospress/woocommerce-subscriptions-resource/blob/b0473c0feaa720c13167225321c360e9bff9d7c4/includes/wcsr-renewal-functions.php#L41) and filtering the result of that function (doesn't feel right to pass a new param to a function just so it can be used in the `apply_filters()`)